### PR TITLE
Add note where to find kernel for ace3ds.com-cards

### DIFF
--- a/ace3ds.com/Use files for r4isdhc.com.cn.txt
+++ b/ace3ds.com/Use files for r4isdhc.com.cn.txt
@@ -1,0 +1,1 @@
+Use files for r4isdhc.com.cn


### PR DESCRIPTION
Because nobody is going to look in a folder with a completely different domain (also applies to r4isdhc.hk etc.) unless being told to do so.